### PR TITLE
Fix InvalidOperationException during UnsafeUnlock

### DIFF
--- a/Signum.Entities.Extensions/Disconnected/DisconnectedMachineEntity.cs
+++ b/Signum.Entities.Extensions/Disconnected/DisconnectedMachineEntity.cs
@@ -30,7 +30,7 @@ namespace Signum.Entities.Disconnected
 
         static Expression<Func<DisconnectedMachineEntity, Interval<int>>> SeedIntervalExpression =
             entity => new Interval<int>(entity.SeedMin, entity.SeedMax);
-        [HiddenProperty]
+        [HiddenProperty, ExpressionField]
         public Interval<int> SeedInterval
         {
             get { return SeedIntervalExpression.Evaluate(this); }


### PR DESCRIPTION
Executing UnsafeUnlock produced an InvalidOperationException: "The member SeedInterval of DisconnectedMachineEntity is not accesible on queries"