### PR TITLE
EmailTemplateEntity.Messages -> MList notification of parent Issue (Entity.GetParentEntity())

### DIFF
--- a/Signum.Entities.Extensions/Mailing/EmailTemplate.cs
+++ b/Signum.Entities.Extensions/Mailing/EmailTemplate.cs
@@ -22,9 +22,12 @@ namespace Signum.Entities.Mailing
     [Serializable, EntityKind(EntityKind.Main, EntityData.Master)]
     public class EmailTemplateEntity : Entity
     {
-        public EmailTemplateEntity() { }
+        public EmailTemplateEntity()
+        {
+            RebindEvents();
+        }
 
-        public EmailTemplateEntity(object queryName)
+        public EmailTemplateEntity(object queryName) : this()
         {
             this.queryName = queryName;
         }


### PR DESCRIPTION
the Messages validation at Save() causes 2 referece null exceptions in Subject & Text, this errors is caused in EmailTemplateLogic.EmailTemplateMessageText_StaticPropertyValidation at message.GetParentEntity() because the MList<> is not transfered the parent entity
see more in: https://github.com/signumsoftware/extensions/issues/102