### PR TITLE
enable changing template before passing it to CreateEmailMessage

### DIFF
--- a/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
+++ b/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
@@ -233,13 +233,20 @@ namespace Signum.Engine.Mailing
             }
         }
 
-        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity model = null, ISystemEmail systemEmail = null, MList<EmailTemplateRecipientEmbedded> additionalRecipients=null)
+        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity model = null, ISystemEmail systemEmail = null)
         {
             EmailTemplateEntity template = EmailTemplatesLazy.Value.GetOrThrow(liteTemplate, "Email template {0} not in cache".FormatWith(liteTemplate));
-            if (additionalRecipients != null)
-            {
-                template.Recipients.AddRange(additionalRecipients);
-            }
+
+            return CreateEmailMessage(template, model, ref systemEmail);
+        }
+
+        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this EmailTemplateEntity template, ModifiableEntity model = null, ISystemEmail systemEmail = null)
+        {
+            return CreateEmailMessage(template, model, ref systemEmail);
+        }
+
+        private static IEnumerable<EmailMessageEntity> CreateEmailMessage(EmailTemplateEntity template, ModifiableEntity model, ref ISystemEmail systemEmail)
+        {
             Entity entity = null;
             if (template.SystemEmail != null)
             {

--- a/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
+++ b/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Signum.Entities.Mailing;
@@ -233,10 +233,13 @@ namespace Signum.Engine.Mailing
             }
         }
 
-        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity model = null, ISystemEmail systemEmail = null)
+        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity model = null, ISystemEmail systemEmail = null, MList<EmailTemplateRecipientEmbedded> additionalRecipients=null)
         {
             EmailTemplateEntity template = EmailTemplatesLazy.Value.GetOrThrow(liteTemplate, "Email template {0} not in cache".FormatWith(liteTemplate));
-
+            if (additionalRecipients != null)
+            {
+                template.Recipients.AddRange(additionalRecipients);
+            }
             Entity entity = null;
             if (template.SystemEmail != null)
             {

--- a/Signum.React.Extensions/Signum.React.Extensions.csproj
+++ b/Signum.React.Extensions/Signum.React.Extensions.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Signum.Analyzer" Version="1.0.0" />
-    <PackageReference Include="Signum.TSGenerator" Version="1.0.1" />
+    <PackageReference Include="Signum.Analyzer" Version="1.0.1" />
+    <PackageReference Include="Signum.TSGenerator" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Signum.React.Extensions/Signum.React.Extensions.csproj
+++ b/Signum.React.Extensions/Signum.React.Extensions.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Signum.Analyzer" Version="1.0.0" />
-    <PackageReference Include="Signum.TSGenerator" Version="1.0.0" />
+    <PackageReference Include="Signum.TSGenerator" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
If we want to change things in an emailTemplate before sending it, we have to pass around the entity instead of getting it from cache inside the createEmailMessage Method