### PR TITLE
invoking OnApplicationServerRestarted moved before StopApplication

### DIFF
--- a/Signum.React.Extensions/Dynamic/DynamicController.cs
+++ b/Signum.React.Extensions/Dynamic/DynamicController.cs
@@ -64,8 +64,8 @@ namespace Signum.React.Dynamic
         public void RestartServer()
         {
             SystemEventLogLogic.Log("DynamicController.RestartServer");
-            lifeTime.StopApplication();
             DynamicCode.OnApplicationServerRestarted?.Invoke();
+            lifeTime.StopApplication();
         }
 
         [HttpGet("api/dynamic/startErrors")]


### PR DESCRIPTION
calling On ApplicationServerRestarted after signalling application to stop, causes its execution to break unfinished.