### PR TITLE
Fixed inconsistent casing to prevent TS error

### DIFF
--- a/Signum.React.Extensions/Files/FileLine.tsx
+++ b/Signum.React.Extensions/Files/FileLine.tsx
@@ -1,4 +1,4 @@
-﻿/// <reference path="filesclient.tsx" />
+﻿/// <reference path="FilesClient.tsx" />
 import * as React from 'react'
 import { classes } from '@framework/Globals'
 import { TypeContext } from '@framework/TypeContext'

--- a/Signum.React.Extensions/Files/MultiFileLine.tsx
+++ b/Signum.React.Extensions/Files/MultiFileLine.tsx
@@ -1,4 +1,4 @@
-/// <reference path="filesclient.tsx" />
+/// <reference path="FilesClient.tsx" />
 import * as React from 'react'
 import { classes } from '@framework/Globals'
 import * as Constructor from '@framework/Constructor'


### PR DESCRIPTION
This fixes:

Type error: File name 'C:/Projects/signum/Extensions/Signum.React.Extensions/Files/FilesClient.tsx' differs from already included file name 'C:/Projects/signum/Extensions/Signum.React.Extensions/Files/filesclient.tsx' only in casing.  TS1149