### PR TITLE
added support to iterate over multiple images with the same title

### DIFF
--- a/Signum.Engine.Extensions/Word/WordImageReplacer.cs
+++ b/Signum.Engine.Extensions/Word/WordImageReplacer.cs
@@ -67,7 +67,7 @@ namespace Signum.Engine.Word
             doc.MainDocumentPart.DeletePart(blips.First().Embed);
 
             var i = 0;
-            var bitmapStack = new Stack<Bitmap>(bitmaps);
+            var bitmapStack = new Stack<Bitmap>(bitmaps.Reverse());
             foreach (var blip in blips)
             {
                 ImagePart img = CreateImagePart(doc, bitmapStack.Pop(), newImagePartId + i, imagePartType);


### PR DESCRIPTION
the added **allowMultiple: true** now allows:
`
sc.Entity.Images.ForEach(i => ReplaceImage(wordDoc, i, "Image", $"imagePart{i.Suffix}"));`

![one](https://user-images.githubusercontent.com/11074890/53252889-402fb580-36c0-11e9-8a48-d561a4f80d87.PNG)

This is very helpfull when you want to list all images of an MList in a report