### PR TITLE
EmailTemplate.CreateEmailMessage add optional parameter to set Culture

### DIFF
--- a/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
+++ b/Signum.Engine.Extensions/Mailing/EmailTemplateLogic.cs
@@ -248,19 +248,19 @@ namespace Signum.Engine.Mailing
             }
         }
 
-        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity? modifiableEntity = null, IEmailModel? model = null)
+        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this Lite<EmailTemplateEntity> liteTemplate, ModifiableEntity? modifiableEntity = null, IEmailModel? model = null, CultureInfo? cultureInfo = null)
         {
             EmailTemplateEntity template = EmailTemplatesLazy.Value.GetOrThrow(liteTemplate, "Email template {0} not in cache".FormatWith(liteTemplate));
 
-            return CreateEmailMessage(template, modifiableEntity, ref model);
+            return CreateEmailMessage(template, modifiableEntity, ref model, cultureInfo);
         }
 
-        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this EmailTemplateEntity template, ModifiableEntity? modifiableEntity = null, IEmailModel? model = null)
+        public static IEnumerable<EmailMessageEntity> CreateEmailMessage(this EmailTemplateEntity template, ModifiableEntity? modifiableEntity = null, IEmailModel? model = null, CultureInfo? cultureInfo = null)
         {
-            return CreateEmailMessage(template, modifiableEntity, ref model);
+            return CreateEmailMessage(template, modifiableEntity, ref model, cultureInfo);
         }
 
-        private static IEnumerable<EmailMessageEntity> CreateEmailMessage(EmailTemplateEntity template, ModifiableEntity? modifiableEntity, ref IEmailModel? model)
+        private static IEnumerable<EmailMessageEntity> CreateEmailMessage(EmailTemplateEntity template, ModifiableEntity? modifiableEntity, ref IEmailModel? model, CultureInfo? cultureInfo = null)
         {
             Entity? entity = null;
             if (template.Model != null)
@@ -277,7 +277,7 @@ namespace Signum.Engine.Mailing
 
             using (template.DisableAuthorization ? ExecutionMode.Global() : null)
             {
-                var emailBuilder = new EmailMessageBuilder(template, entity, model);
+                var emailBuilder = new EmailMessageBuilder(template, entity, model, cultureInfo);
                 return emailBuilder.CreateEmailMessageInternal().ToList();
             }
         }

--- a/Signum.Engine.Extensions/Mailing/EmailTemplateRenderer.cs
+++ b/Signum.Engine.Extensions/Mailing/EmailTemplateRenderer.cs
@@ -20,8 +20,9 @@ namespace Signum.Engine.Mailing
         object queryName;
         QueryDescription qd;
         EmailSenderConfigurationEntity? smtpConfig;
+        CultureInfo? cultureInfo;
 
-        public EmailMessageBuilder(EmailTemplateEntity template, Entity? entity, IEmailModel? systemEmail)
+        public EmailMessageBuilder(EmailTemplateEntity template, Entity? entity, IEmailModel? systemEmail, CultureInfo? cultureInfo)
         {
             this.template = template;
             this.entity = entity;
@@ -30,7 +31,7 @@ namespace Signum.Engine.Mailing
             this.queryName = QueryLogic.ToQueryName(template.Query.Key);
             this.qd = QueryLogic.Queries.QueryDescription(queryName);
             this.smtpConfig = EmailTemplateLogic.GetSmtpConfiguration?.Invoke(template, (systemEmail?.UntypedEntity as Entity)?.ToLiteFat(), null);
-
+            this.cultureInfo = cultureInfo;
         }
 
         ResultTable table = null!;
@@ -49,7 +50,8 @@ namespace Signum.Engine.Mailing
                     EmailMessageEntity email;
                     try
                     {
-                        CultureInfo ci = recipients.Where(a => a.Kind == EmailRecipientKind.To).Select(a => a.OwnerData.CultureInfo).FirstOrDefault()?.ToCultureInfo() ??
+                        CultureInfo ci = this.cultureInfo ?? 
+                            recipients.Where(a => a.Kind == EmailRecipientKind.To).Select(a => a.OwnerData.CultureInfo).FirstOrDefault()?.ToCultureInfo() ??
                             EmailLogic.Configuration.DefaultCulture.ToCultureInfo();
 
                         email = new EmailMessageEntity


### PR DESCRIPTION
Allow set optional CultureInfo parameter on creacting EmailMessage from an EmailTemplate instead of taking it from (optional) EmailTemplate Default From