### PR TITLE
force null value / make output nullable

### DIFF
--- a/Signum.Engine.Extensions/SMS/SMSProcessLogic.cs
+++ b/Signum.Engine.Extensions/SMS/SMSProcessLogic.cs
@@ -123,7 +123,7 @@ namespace Signum.Engine.SMS
         private static ProcessEntity UpdateMessages(List<SMSMessageEntity> messages)
         {
             if (!messages.Any())
-                return null;
+                return null!;
 
             SMSUpdatePackageEntity package = new SMSUpdatePackageEntity().Save();
 

--- a/Signum.Engine.Extensions/SMS/SMSProcessLogic.cs
+++ b/Signum.Engine.Extensions/SMS/SMSProcessLogic.cs
@@ -120,10 +120,10 @@ namespace Signum.Engine.SMS
 
 
 
-        private static ProcessEntity UpdateMessages(List<SMSMessageEntity> messages)
+        private static ProcessEntity? UpdateMessages(List<SMSMessageEntity> messages)
         {
             if (!messages.Any())
-                return null!;
+                return null;
 
             SMSUpdatePackageEntity package = new SMSUpdatePackageEntity().Save();
 


### PR DESCRIPTION
Hi, maybe better make output nullable? 
private static ProcessEntity? UpdateMessages(List<SMSMessageEntity> messages)
        {
            if (!messages.Any())
                return null;